### PR TITLE
fix: retry on 401 Unauthorized during TUS uploads

### DIFF
--- a/ktus/build.gradle.kts
+++ b/ktus/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.ldartools"
-version = "1.0.1"
+version = "1.0.2"
 
 kotlin {
     jvm()

--- a/ktus/src/commonMain/kotlin/com/ldartools/ktus/Retry.kt
+++ b/ktus/src/commonMain/kotlin/com/ldartools/ktus/Retry.kt
@@ -18,12 +18,16 @@ internal suspend fun <T> retryWithBackoff(
         try {
             return block()
         } catch (e: ClientRequestException) {
-            // 4xx errors: fail fast except for expired uploads
+            // 4xx errors: fail fast except for expired uploads and auth failures
             val statusCode = e.response.status.value
             if (statusCode == HttpStatusCode.NotFound.value || statusCode == HttpStatusCode.Gone.value) {
                 throw TusUploadExpiredException()
             }
-            throw e
+            if (statusCode == HttpStatusCode.Unauthorized.value) {
+                // 401 is retryable — the block() lambda will refresh the auth token on next attempt
+            } else {
+                throw e
+            }
         } catch (e: ServerResponseException) {
             // 5xx server errors are transient — allow retrying.
         } catch (e: TusProtocolException) {

--- a/ktus/src/commonMain/kotlin/com/ldartools/ktus/Retry.kt
+++ b/ktus/src/commonMain/kotlin/com/ldartools/ktus/Retry.kt
@@ -24,7 +24,7 @@ internal suspend fun <T> retryWithBackoff(
                 throw TusUploadExpiredException()
             }
             if (statusCode == HttpStatusCode.Unauthorized.value) {
-                // 401 is retryable — the block() lambda will refresh the auth token on next attempt
+                // 401 is retryable — allowing the caller's block() lambda to refresh the auth token on the next attempt
             } else {
                 throw e
             }

--- a/ktus/src/commonTest/kotlin/com/ldartools/ktus/test/RetryTest.kt
+++ b/ktus/src/commonTest/kotlin/com/ldartools/ktus/test/RetryTest.kt
@@ -98,6 +98,30 @@ class RetryTest {
     }
 
     @Test
+    fun `retries on 401 and succeeds`() = runTest {
+        var attempts = 0
+        val result = retryWithBackoff(defaultOptions) {
+            attempts++
+            if (attempts < 2) throw mockClientRequestException(HttpStatusCode.Unauthorized)
+            "success"
+        }
+        assertEquals("success", result)
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun `fails after max retries with persistent 401`() = runTest {
+        var attempts = 0
+        assertFailsWith<ClientRequestException> {
+            retryWithBackoff(defaultOptions) {
+                attempts++
+                throw mockClientRequestException(HttpStatusCode.Unauthorized)
+            }
+        }
+        assertEquals(defaultOptions.maxRetries, attempts)
+    }
+
+    @Test
     fun `exponential backoff delays are correct`() = runTest {
         var attempts = 0
         var expectedElapsed = 0.0


### PR DESCRIPTION
## Summary
- **Add 401 to retryable errors** in `retryWithBackoff` — previously all 4xx errors (except 404/410) failed immediately, so an expired JWT mid-upload killed the operation with no recovery
- Since the `block()` lambda already refreshes the auth token on every retry attempt, we just need to let the retry happen instead of failing fast
- **Version bump** to 1.0.2

## Test plan
- [x] New test: 401 followed by success — verifies retry works
- [x] New test: persistent 401 (all attempts fail) — verifies max retries respected and exception propagates
- [x] All existing tests pass (`./gradlew :ktus:jvmTest`)
- [ ] Publish 1.0.2 to Maven Central after merge
- [x] Manual: TUS upload recovers from 401 mid-upload (visible in logs: 401 → retry → fresh token → success)